### PR TITLE
Fetch data from drupal url

### DIFF
--- a/src/plugins/import-content-type/server/src/controllers/controller.ts
+++ b/src/plugins/import-content-type/server/src/controllers/controller.ts
@@ -2,6 +2,8 @@ import type { Core } from '@strapi/strapi';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import axios from 'axios';
+import https from 'https';
 
 const controller = ({ strapi }: { strapi: Core.Strapi }) => ({
   index(ctx) {
@@ -267,6 +269,40 @@ const controller = ({ strapi }: { strapi: Core.Strapi }) => ({
     } catch (error) {
       strapi.log.error(`Local file import error: ${error.message}`);
       return ctx.badRequest(error.message || 'Error importing from local file');
+    }
+  },
+
+  async fetchDrupalData(ctx) {
+    try {
+      const { baseUrl, endpoint, params } = ctx.request.body;
+      if (!baseUrl || !endpoint) {
+        return ctx.badRequest('baseUrl and endpoint are required in the request body');
+      }
+      let page = 0;
+      let allResults = [];
+      let keepFetching = true;
+      while (keepFetching) {
+        const url = `${baseUrl.replace(/\/$/, '')}/${endpoint.replace(/^\//, '')}`;
+        const queryParams = { ...params, page: { limit: 50, offset: page * 50 } };
+        const agent = new https.Agent({ rejectUnauthorized: false });
+        try {
+          const response = await axios.get(url, { params: queryParams, httpsAgent: agent });
+          const data = response.data && response.data.data ? response.data.data : [];
+          if (Array.isArray(data) && data.length > 0) {
+            allResults = allResults.concat(data);
+            page++;
+          } else {
+            keepFetching = false;
+          }
+        } catch (err) {
+          strapi.log.error(`Error fetching from Drupal: ${err.message}`);
+          return ctx.badRequest(`Error fetching from Drupal: ${err.message}`);
+        }
+      }
+      ctx.send({ success: true, count: allResults.length, data: allResults });
+    } catch (error) {
+      strapi.log.error(`fetchDrupalData error: ${error.message}`);
+      return ctx.badRequest(error.message || 'Error fetching from Drupal');
     }
   },
 });

--- a/src/plugins/import-content-type/server/src/controllers/controller.ts
+++ b/src/plugins/import-content-type/server/src/controllers/controller.ts
@@ -274,17 +274,19 @@ const controller = ({ strapi }: { strapi: Core.Strapi }) => ({
 
   async fetchDrupalData(ctx) {
     try {
-      const { baseUrl, endpoint, params } = ctx.request.body;
+      const { baseUrl, endpoint, params, contentType, fieldsMapping, relationsMapping } =
+        ctx.request.body;
       if (!baseUrl || !endpoint) {
         return ctx.badRequest('baseUrl and endpoint are required in the request body');
       }
       let page = 0;
       let allResults = [];
       let keepFetching = true;
+      const agent = new https.Agent({ rejectUnauthorized: false });
+
       while (keepFetching) {
         const url = `${baseUrl.replace(/\/$/, '')}/${endpoint.replace(/^\//, '')}`;
         const queryParams = { ...params, page: { limit: 50, offset: page * 50 } };
-        const agent = new https.Agent({ rejectUnauthorized: false });
         try {
           const response = await axios.get(url, { params: queryParams, httpsAgent: agent });
           const data = response.data && response.data.data ? response.data.data : [];
@@ -299,6 +301,19 @@ const controller = ({ strapi }: { strapi: Core.Strapi }) => ({
           return ctx.badRequest(`Error fetching from Drupal: ${err.message}`);
         }
       }
+
+      // If strapi param is true, transform the data
+      if (params && params.strapi && contentType) {
+        const service = strapi.plugin('import-content-type').service('service');
+        const transformed = await service.transformDrupalToStrapi(
+          contentType,
+          allResults,
+          fieldsMapping || {},
+          relationsMapping || {}
+        );
+        return ctx.send({ success: true, count: transformed.length, data: transformed });
+      }
+
       ctx.send({ success: true, count: allResults.length, data: allResults });
     } catch (error) {
       strapi.log.error(`fetchDrupalData error: ${error.message}`);

--- a/src/plugins/import-content-type/server/src/routes/content-api.ts
+++ b/src/plugins/import-content-type/server/src/routes/content-api.ts
@@ -44,4 +44,13 @@ export default [
       auth: false, // Make this endpoint public
     },
   },
+  {
+    method: 'POST',
+    path: '/fetch-drupal',
+    handler: 'controller.fetchDrupalData',
+    config: {
+      policies: [],
+      auth: false, // Make this endpoint public
+    },
+  },
 ];

--- a/src/plugins/import-content-type/server/src/services/service.ts
+++ b/src/plugins/import-content-type/server/src/services/service.ts
@@ -544,6 +544,38 @@ const service = ({ strapi }: { strapi: Core.Strapi }) => ({
       throw error;
     }
   },
+
+  async transformDrupalToStrapi(
+    contentType,
+    drupalData,
+    fieldsMapping = {},
+    relationsMapping = {}
+  ) {
+    // Map Drupal JSON:API data to Strapi content-type format, including relations
+    return drupalData.map((item) => {
+      const strapiItem: Record<string, any> = {};
+
+      // Map fields
+      for (const [strapiField, drupalField] of Object.entries(fieldsMapping)) {
+        strapiItem[strapiField] = item.attributes?.[drupalField as string];
+      }
+
+      // Map relationships
+      for (const [strapiRel, drupalRel] of Object.entries(relationsMapping)) {
+        const relData = item.relationships?.[drupalRel as string]?.data;
+        if (Array.isArray(relData)) {
+          strapiItem[strapiRel] = relData.map((rel: any) => rel.id);
+        } else if (relData && relData.id) {
+          strapiItem[strapiRel] = relData.id;
+        }
+      }
+
+      // Optionally, include the original Drupal id for reference
+      strapiItem['drupal_id'] = item.id;
+
+      return strapiItem;
+    });
+  },
 });
 
 export default service;


### PR DESCRIPTION
get all drupal data and convert in strapi 5 data

payload - 
**1.  add drupal data**
{
  "baseUrl": "https://bjp.org/jsonapi",
  "endpoint": "taxonomy_term/ac_type",
  "params": { }
}

**2.  change in strapi data**
{
  "baseUrl": "https://bjp.org/jsonapi",
  "endpoint": "taxonomy_term/ac_type",
  "params": { "strapi": true },
  "contentType": "ac-type",
  "fieldsMapping": {
    "name": "name",
    "description": "description",
    "language": "langcode"
  },
  "relationsMapping": {
    
  }
}